### PR TITLE
Use custom ecmarkup

### DIFF
--- a/index.html
+++ b/index.html
@@ -2989,7 +2989,7 @@ li.menu-search-result-term:before {
 }
 </style><style>@media print {
 body {
-  font-family: Arial;
+  font-family: Arial, Helvetica, sans-serif;
   font-size: 10pt;
   background: #fff;
   color: #000;
@@ -3040,6 +3040,11 @@ emu-figure img {
   max-width: none;
 }
 
+#toc a,
+#toc var {
+  color: #000;
+}
+
 #toc a[href] {
   background: #fff;
   padding-right: 0.5em;
@@ -3068,6 +3073,10 @@ emu-figure img {
   display: none;
 }
 
+#toc > ol > li {
+  margin-top: 1ex;
+}
+
 #toc,
 #spec-container > emu-intro,
 #spec-container > emu-annex {
@@ -3092,7 +3101,8 @@ emu-table th,
 emu-table td,
 emu-alg li,
 pre,
-h1 {
+h1,
+#metadata-block {
   break-inside: avoid;
 }
 
@@ -3274,7 +3284,7 @@ emu-intro {
       <li>If <var>x</var> is <emu-xref href="#dfn-decimal128-zero" id="_ref_13"><a href="#dfn-decimal128-zero">zero</a></emu-xref>, the <emu-xref href="#mathematical-value-of"><a href="https://tc39.es/ecma262/#mathematical-value-of">mathematical value of</a></emu-xref> <var>x</var> is 0</li>
       <li>If <var>x</var> is non-<emu-xref href="#dfn-decimal128-zero" id="_ref_14"><a href="#dfn-decimal128-zero">zero</a></emu-xref>, the <emu-xref href="#mathematical-value-of"><a href="https://tc39.es/ecma262/#mathematical-value-of">mathematical value of</a></emu-xref> <var>x</var> is v × 10<sup><var>q</var></sup></li>
     </ul>
-    <p>A Decimal128 value is said to be <dfn id="dfn-decimal128-finite" tabindex="-1">finite</dfn> if it has the form « <var>v</var>, <var>q</var> ». A <dfn id="dfn-decimal128-zero" tabindex="-1">zero</dfn> Decimal128 value is a <emu-xref href="#dfn-decimal128-finite" id="_ref_15"><a href="#dfn-decimal128-finite">finite</a></emu-xref> Decimal128 value of the form « 0<sub>𝔻</sub>, <var>q</var> »<sub>𝔻</sub> or « -0<sub>𝔻</sub>, <var>q</var> »<sub>𝔻</sub>. A <emu-xref href="#dfn-decimal128-finite" id="_ref_16"><a href="#dfn-decimal128-finite">finite</a></emu-xref> non-<emu-xref href="#dfn-decimal128-zero" id="_ref_17"><a href="#dfn-decimal128-zero">zero</a></emu-xref> Decimal128 value is one of the form « <var>v</var>, <var>q</var> »<sub>𝔻</sub> where <var>v</var> is a <emu-xref href="#dfn-decimal128-mathematical-value" id="_ref_18"><a href="#dfn-decimal128-mathematical-value">mathematical value</a></emu-xref>. A <emu-xref href="#dfn-decimal128-finite" id="_ref_19"><a href="#dfn-decimal128-finite">finite</a></emu-xref> Decimal128 value « <var>v</var>, <var>q</var> » is said to be <dfn tabindex="-1">negative</dfn> if either <var>v</var> is <emu-val>-0</emu-val><sub>D</sub> or <var>v</var> is a real number such that <var>v</var> &lt; 0.</p>
+    <p>A Decimal128 value is said to be <dfn id="dfn-decimal128-finite" tabindex="-1">finite</dfn> if it has the form « <var>v</var>, <var>q</var> ». A <dfn id="dfn-decimal128-zero" tabindex="-1">zero</dfn> Decimal128 value is a <emu-xref href="#dfn-decimal128-finite" id="_ref_15"><a href="#dfn-decimal128-finite">finite</a></emu-xref> Decimal128 value of the form « 0<sub>𝔻</sub>, <var>q</var> »<sub>𝔻</sub> or « -0<sub>𝔻</sub>, <var>q</var> »<sub>𝔻</sub>. A <emu-xref href="#dfn-decimal128-finite" id="_ref_16"><a href="#dfn-decimal128-finite">finite</a></emu-xref> non-<emu-xref href="#dfn-decimal128-zero" id="_ref_17"><a href="#dfn-decimal128-zero">zero</a></emu-xref> Decimal128 value is one of the form « <var>v</var>, <var>q</var> »<sub>𝔻</sub> where <var>v</var> is a <emu-xref href="#dfn-decimal128-mathematical-value" id="_ref_18"><a href="#dfn-decimal128-mathematical-value">mathematical value</a></emu-xref>. A <emu-xref href="#dfn-decimal128-finite" id="_ref_19"><a href="#dfn-decimal128-finite">finite</a></emu-xref> Decimal128 value « <var>v</var>, <var>q</var> » is said to be <dfn tabindex="-1">negative</dfn> if either <var>v</var> is -0<sub>D</sub> or <var>v</var> is a real number such that <var>v</var> &lt; 0.</p>
     <emu-note><span class="note">Note 1</span><div class="note-contents">
       <p>The <var>v</var> component of a <emu-xref href="#dfn-decimal128-finite" id="_ref_20"><a href="#dfn-decimal128-finite">finite</a></emu-xref> non-<emu-xref href="#dfn-decimal128-zero" id="_ref_21"><a href="#dfn-decimal128-zero">zero</a></emu-xref> Decimal128 value « <var>v</var>, <var>q</var> »<sub>𝔻</sub> is a rational number.</p>
     </div></emu-note>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@tc39/ecma262-biblio": "2.1",
         "@tc39/ecma402-biblio": "^2.1.1050",
-        "ecmarkup": "^18.1.1"
+        "ecmarkup": "github:jessealama/ecmarkup#permit-decimal-subscript-D"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -183,15 +183,15 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "2.1.2722",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2722.tgz",
-      "integrity": "sha512-0GgpyXfAJYa5acAnA84SACZu814m/1Uuu+Apq575rumXid7WseOWxDj6/oMaTyAL1DI3IbI3Ce/hTLPVbQpDDg==",
+      "version": "2.1.2726",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2726.tgz",
+      "integrity": "sha512-LUrE4faprQH9BruiPBPXO1xOOEJ66g6aRMjZFouLuSZuQVNfyl2QkmwYX/uSXFuvobGfQOQG8/kb3fRnXRtJJg==",
       "dev": true
     },
     "node_modules/@tc39/ecma402-biblio": {
-      "version": "2.1.1053",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma402-biblio/-/ecma402-biblio-2.1.1053.tgz",
-      "integrity": "sha512-BoDYEvI63ViEwKUOu+l5C5uWUv78Job8igiXYLoshEWh8L6KxfZAWYAIfCEhQeN9lQxHyu5WCdSBJfgpgZ3xxg==",
+      "version": "2.1.1055",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma402-biblio/-/ecma402-biblio-2.1.1055.tgz",
+      "integrity": "sha512-hjzB6Y6ugX45BT8RmYpja2Khp3MZshylmn0leEOynstVSG7Hp0t6NPPNI3cl7OFRF518Zklw8s9Xe3Lrcv2Twg==",
       "dev": true
     },
     "node_modules/@tootallnate/once": {
@@ -305,12 +305,12 @@
       "dev": true
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -600,8 +600,7 @@
     },
     "node_modules/ecmarkup": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-18.3.1.tgz",
-      "integrity": "sha512-ouyfwgVjtvyF9AdAQnI9krCWNE5srK90XGPym8vs6WPtjUso6Pq887DwAYBDbga9lrfwezWo5n8hGu9amYYu1g==",
+      "resolved": "git+ssh://git@github.com/jessealama/ecmarkup.git#a2590e066be0e1752454e4667c9e3720d3e0d217",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -735,9 +734,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -990,12 +989,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -1042,9 +1041,9 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "npm run build-loose -- --watch",
     "build": "npm run build-loose --",
-    "build-loose": "ecmarkup --verbose --lint-spec --load-biblio @tc39/ecma262-biblio --load-biblio @tc39/ecma402-biblio spec.emu index.html"
+    "build-loose": "ecmarkup --verbose --lint-spec --strict --load-biblio @tc39/ecma262-biblio --load-biblio @tc39/ecma402-biblio spec.emu index.html"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,6 @@
   "devDependencies": {
     "@tc39/ecma262-biblio": "2.1",
     "@tc39/ecma402-biblio": "^2.1.1050",
-    "ecmarkup": "^18.1.1"
+    "ecmarkup": "github:jessealama/ecmarkup#permit-decimal-subscript-D"
   }
 }

--- a/spec.emu
+++ b/spec.emu
@@ -83,7 +83,7 @@ location: https://github.com/tc39/proposal-decimal/
       <li>If _x_ is zero, the mathematical value of _x_ is 0</li>
       <li>If _x_ is non-zero, the mathematical value of _x_ is v × 10<sup>_q_</sup></li>
     </ul>
-    <p>A Decimal128 value is said to be <dfn id="dfn-decimal128-finite">finite</dfn> if it has the form « _v_, _q_ ». A <dfn id="dfn-decimal128-zero">zero</dfn> Decimal128 value is a finite Decimal128 value of the form « 0<sub>𝔻</sub>, _q_ »<sub>𝔻</sub> or « -0<sub>𝔻</sub>, _q_ »<sub>𝔻</sub>. A finite non-zero Decimal128 value is one of the form « _v_, _q_ »<sub>𝔻</sub> where _v_ is a mathematical value. A finite Decimal128 value « _v_, _q_ » is said to be <dfn>negative</dfn> if either _v_ is *-0*<sub>D</sub> or _v_ is a real number such that _v_ < 0.</p>
+    <p>A Decimal128 value is said to be <dfn id="dfn-decimal128-finite">finite</dfn> if it has the form « _v_, _q_ ». A <dfn id="dfn-decimal128-zero">zero</dfn> Decimal128 value is a finite Decimal128 value of the form « 0<sub>𝔻</sub>, _q_ »<sub>𝔻</sub> or « -0<sub>𝔻</sub>, _q_ »<sub>𝔻</sub>. A finite non-zero Decimal128 value is one of the form « _v_, _q_ »<sub>𝔻</sub> where _v_ is a mathematical value. A finite Decimal128 value « _v_, _q_ » is said to be <dfn>negative</dfn> if either _v_ is -0<sub>D</sub> or _v_ is a real number such that _v_ < 0.</p>
     <emu-note>
       <p>The _v_ component of a finite non-zero Decimal128 value « _v_, _q_ »<sub>𝔻</sub> is a rational number.</p>
     </emu-note>


### PR DESCRIPTION
Following the suggestions in #122 (the "Format" section), we introduce a new universe of specifications values for decimal. We'll follow the suggestion to use `<sub>𝔻</sub>` as a marker for such values. To generate the spec HTML in strict mode, though -- which we ought to do -- we run up against the issue that `<sub>𝔻</sub>` is an unknown notational convention, so we consistently get many errors. Here, we depend upon [a custom version of ecmarkup](https://github.com/jessealama/ecmarkup/tree/permit-decimal-subscript-D) that recognizes this new convention. In the near future, we hope to settle on this notational convention (or possibly a different one) and integrate that change into the official ecmarkup code base, at which point we can revert this change. For now, we need to resort to a hack to get things to work.

Thanks to @romulocintra for the suggestion.