### PR TITLE
Remove obsolete README section with broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,10 +330,6 @@ cases. Further discussion:
 
 One option that’s raised is allowing for greater precision in more capable environments. However, Decimal is all about avoiding unintended rounding. If rounding behavior depended on the environment, the goal would be compromised in those environments. Instead, this proposal attempts to find a single set of semantics that can be applied globally.
 
-### What about decimals elsewhere (the JS ecosystem, other programming languages/systems)?
-
-See [COMPARISON.md](./COMPARISON.md) for details.
-
 ### How does this proposal relate to other TC39 proposals like operator overloading?
 
 See [RELATED.md](./RELATED.md) for details.


### PR DESCRIPTION
The `COMPARISON.md` file was removed as "obsolete" in this PR: https://github.com/tc39/proposal-decimal/pull/178

However, the section in the README that linked to it remained. That link is now dead. This PR removes this now-obsolete section from README.md.