### PR TITLE
Add `Decimal.Amount` example and remove discussion of performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ let exchangeRateEurToUsd = new Decimal(1.09);
 let amountInUsd = new Decimal(450.27);
 let exchangeRateUsdToEur = new Decimal(1).divide(exchangeRateEurToUsd);
 let amountInEur = exchangeRateUsdToEur.multiply(amountInUsd);
-let opts = { style: "currency", currency: "USD" };
+let opts = { style: "currency", currency: "EUR" };
 let formatter = new Intl.NumberFormat("en-US", opts);
 let amount = Decimal.Amount(amountInEur).with({ fractionDigits: 2 });
 console.log(formatter.format(amount));

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ console.log(formatter.format(amount));
 We propose a `Decimal.Amount` object to store a Decimal value together with precision information. This is especially useful in formatting Decimal values, especially in internationalization and localization contexts.
 
 ```js
-let a = Decimal.Amount.from("1.90").with({ fractionDigit: 4 });
+let a = Decimal.Amount.from("1.90").with({ fractionDigits: 4 });
 const formatter = new Intl.NumberFormat("de-DE");
 formatter.format(a); // "1,9000"
 ```


### PR DESCRIPTION
In the May 2025 plenary we're working on polishing the README. Let's use this PR to do the work.